### PR TITLE
Prevent cross origin error when using w/ React

### DIFF
--- a/lib/shared/get-colors.js
+++ b/lib/shared/get-colors.js
@@ -30,6 +30,7 @@ module.exports = (imagePal, { srcUrl, width, height, imageEl, canvasEl, inputEl,
   img.addEventListener('error', imgOnError, false);
 
   if (srcUrl) {
+    img.crossOrigin = "Anonymous";
     img.src = srcUrl;
   }
 


### PR DESCRIPTION
For some reason using the srcUrl option consistently throws a cross origin error

"Unable to get image data from canvas because the canvas has been tainted by
cross-origin data." 

Adding the anonymous origin resolves this issue.